### PR TITLE
Enforce HTTP1

### DIFF
--- a/lib/buildkite_test_collector/http_transport.ex
+++ b/lib/buildkite_test_collector/http_transport.ex
@@ -15,7 +15,7 @@ defmodule BuildkiteTestCollector.HttpTransport do
   """
   @spec send(Payload.t()) :: {:ok, map} | {:error, any}
   def send(payload) do
-    case post(endpoint(), payload, headers: headers()) do
+    case post(endpoint(), payload, headers: headers(), opts: [adapter: [protocols: [:http1]]]) do
       {:ok, _} -> {:ok, %{payload: %{data: [], data_size: 0}}}
       {:error, reason} -> {:error, reason}
     end


### PR DESCRIPTION
With large payloads the HTTP client fails with the error as described in https://github.com/elixir-tesla/tesla/issues/394.